### PR TITLE
3156 - Add Amido.Stacks.Messaging.Azure.ServiceBus dependency to project

### DIFF
--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
@@ -1,45 +1,72 @@
 ﻿{
-    "Serilog": {
-        "Using": [
-            "Serilog.Sinks.Console",
-            "Serilog.Sinks.ApplicationInsights"
-        ],
-        "MinimumLevel": {
-            "Default": "Debug",
-            "Override": {}
-        },
-        "WriteTo": [
-            { "Name": "Console" },
-            {
-                "Name": "ApplicationInsights",
-                "Args": {
-                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-                }
-            }
-        ],
-        "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
-        "Destructure": [],
-        "Properties": {
-            "Application": "Menu API"
-        }
-    },
-    "AllowedHosts": "*",
-    "CosmosDb": {
-        "DatabaseAccountUri": "https://localhost:8081/",
-        "DatabaseName": "Stacks",
-        "SecurityKeySecret": {
-            "Identifier": "COSMOSDB_KEY",
-            "Source": "Environment"
-        }
-    },
-    "JwtBearerAuthentication": {
-        "Audience": "<TODO>",
-        "Authority": "<TODO>",
-        "Enabled": false,
-        "OpenApi": {
-            "AuthorizationUrl": "<TODO>",
-            "ClientId": "<TODO>",
-            "TokenUrl": "<TODO>"
-        }
-    }
+	"Serilog": {
+		"Using": [
+			"Serilog.Sinks.Console",
+			"Serilog.Sinks.ApplicationInsights"
+		],
+		"MinimumLevel": {
+			"Default": "Debug",
+			"Override": {}
+		},
+		"WriteTo": [
+			{
+				"Name": "Console"
+			},
+			{
+				"Name": "ApplicationInsights",
+				"Args": {
+					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+				}
+			}
+		],
+		"Enrich": [
+			"FromLogContext",
+			"WithMachineName",
+			"WithThreadId"
+		],
+		"Destructure": [],
+		"Properties": {
+			"Application": "Menu API"
+		}
+	},
+	"AllowedHosts": "*",
+	"CosmosDb": {
+		"DatabaseAccountUri": "https://localhost:8081/",
+		"DatabaseName": "Stacks",
+		"SecurityKeySecret": {
+			"Identifier": "COSMOSDB_KEY",
+			"Source": "Environment"
+		}
+	},
+	"JwtBearerAuthentication": {
+		"Audience": "<TODO>",
+		"Authority": "<TODO>",
+		"Enabled": false,
+		"OpenApi": {
+			"AuthorizationUrl": "<TODO>",
+			"ClientId": "<TODO>",
+			"TokenUrl": "<TODO>"
+		}
+	},
+	"ServiceBusSender": {
+		"Queues": [
+			{
+				"Name": "notifications-command",
+				"ConnectionStringSecret": {
+					"Identifier": "SERVICEBUS_CONNECTIONSTRING",
+					"Source": "Environment"
+				}
+			}
+		],
+		"Routes": {
+			"QueueRoutes": [
+				{
+					"Name": "notifications-command",
+					"Types": [
+						"Amido.Stacks.Messaging.Commands.NotifyCommand"
+					]
+				}
+			]
+		}
+	}
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
@@ -48,25 +48,27 @@
 			"TokenUrl": "<TODO>"
 		}
 	},
-	"ServiceBusSender": {
-		"Queues": [
-			{
-				"Name": "notifications-command",
-				"ConnectionStringSecret": {
-					"Identifier": "SERVICEBUS_CONNECTIONSTRING",
-					"Source": "Environment"
-				}
-			}
-		],
-		"Routes": {
-			"QueueRoutes": [
+	"ServiceBusConfiguration": {
+		"Sender": {
+			"Topics": [
 				{
-					"Name": "notifications-command",
-					"Types": [
-						"Amido.Stacks.Messaging.Commands.NotifyCommand"
-					]
+					"Name": "servicebus-topic-lius",
+					"ConnectionStringSecret": {
+						"Identifier": "SERVICEBUS_CONNECTIONSTRING",
+						"Source": "Environment"
+					}
 				}
-			]
+			],
+			"Routes": {
+				"QueueRoutes": [
+					{
+						"Name": "servicebus-topic-lius",
+						"Types": [
+							"Amido.Stacks.Messaging.Commands.NotifyCommand"
+						]
+					}
+				]
+			}
 		}
 	}
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
@@ -11,5 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.3"/>
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.1"/>
   </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.3"/>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.1"/>
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.8"/>
   </ItemGroup>
 </Project>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
@@ -5,7 +5,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.12"/>
+    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17"/>
     <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0"/>
     <PackageReference Include="NSubstitute" Version="4.2.2"/>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
@@ -26,7 +26,7 @@
         <PackageReference Include="Amido.Stacks.Testing" Version="0.2.10" />
         <PackageReference Include="AutoFixture" Version="4.17.0" />
         <PackageReference Include="AutoFixture.Xunit2" Version="4.17.0" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.16" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
         <PackageReference Include="NSubstitute" Version="4.2.2" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -6,6 +6,7 @@ using Amido.Stacks.Configuration.Extensions;
 using Amido.Stacks.Data.Documents.CosmosDB;
 using Amido.Stacks.Data.Documents.CosmosDB.Extensions;
 using Amido.Stacks.DependencyInjection;
+using Amido.Stacks.Messaging.Azure.ServiceBus.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Serilog;
@@ -45,7 +46,11 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
             services.AddCosmosDB();
 
             //TODO: Evaluate if event publishers should be generic, probably not, EventHandler are generic tough
-            AddEventPublishers(services);
+            // AddEventPublishers(context, services);
+
+            // Azure Service Bus
+            services.Configure<ServiceBusSenderConfiguration>(context.Configuration.GetSection("ServiceBusSender"))
+                .AddServiceBus();
 
             if (Environment.GetEnvironmentVariable("USE_MEMORY_STORAGE") == null)
                 services.AddTransient<IMenuRepository, MenuRepository>();
@@ -79,7 +84,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
             }
         }
 
-        private static void AddEventPublishers(IServiceCollection services)
+        private static void AddEventPublishers(WebHostBuilderContext context, IServiceCollection services)
         {
             log.Information("Loading implementations of {interface}", typeof(IApplicationEventPublisher).Name);
             var definitions = typeof(DummyEventPublisher).Assembly.GetImplementationsOf(typeof(IApplicationEventPublisher));

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -9,7 +9,6 @@ using Amido.Stacks.DependencyInjection;
 using Amido.Stacks.Messaging.Azure.ServiceBus.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Serilog;
 using xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers;
 using xxAMIDOxx.xxSTACKSxx.Application.Integration;

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -9,6 +9,7 @@ using Amido.Stacks.DependencyInjection;
 using Amido.Stacks.Messaging.Azure.ServiceBus.Configuration;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Serilog;
 using xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers;
 using xxAMIDOxx.xxSTACKSxx.Application.Integration;
@@ -40,7 +41,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
         /// <param name="services"></param>
         public static void ConfigureProductionDependencies(WebHostBuilderContext context, IServiceCollection services)
         {
-            services.Configure<CosmosDbConfiguration>(context.Configuration.GetSection("CosmosDB"));
+            services.Configure<CosmosDbConfiguration>(context.Configuration.GetSection("CosmosDb"));
 
             services.AddSecrets();
             services.AddCosmosDB();
@@ -49,8 +50,8 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
             // AddEventPublishers(context, services);
 
             // Azure Service Bus
-            services.Configure<ServiceBusSenderConfiguration>(context.Configuration.GetSection("ServiceBusSender"))
-                .AddServiceBus();
+            services.Configure<ServiceBusConfiguration>(context.Configuration.GetSection("ServiceBusConfiguration"));
+            services.AddServiceBus();
 
             if (Environment.GetEnvironmentVariable("USE_MEMORY_STORAGE") == null)
                 services.AddTransient<IMenuRepository, MenuRepository>();

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -7,13 +7,14 @@
 
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.15" />
-    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.12" />
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.1"/>
+    <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.16" />
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="5.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="3.1.16" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.8" />
   </ItemGroup>
 
     <ItemGroup>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.15" />
-	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.1"/>
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.8"/>
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />


### PR DESCRIPTION
[3156 - Add Amido.Stacks.Messaging.Azure.ServiceBus dependency to project]

#### 📲 What

Add a dependency to the Amido.Stacks.Messagings.Azure.ServiceBus library

#### 🤔 Why

That library is used to facilitate functionality for publishing and listening of events to Azure Service Bus
