### PR TITLE
Test/3111 functional tests - Indicative comment for the steps once sub/pub is used in the real project

### DIFF
--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/CreateCategoryTests.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/CreateCategoryTests.cs
@@ -31,6 +31,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Stories
                 .And(step => categorySteps.GivenIHaveSpecfiedAFullCategory())
                 .When(step => categorySteps.WhenICreateTheCategoryForAnExistingMenu())
                 .Then(step => categorySteps.ThenTheCategoryHasBeenCreated())
+                // .Then(step => categorySteps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/CreateItemTests.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/CreateItemTests.cs
@@ -31,6 +31,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Stories
                 .And(step => itemSteps.GivenIHaveSpecfiedAFullItem())
                 .When(step => itemSteps.WhenICreateTheItemForAnExistingMenuAndCategory())
                 .Then(step => itemSteps.ThenTheItemHasBeenCreated())
+                //.Then(step => itemSteps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/CreateMenuTests.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/CreateMenuTests.cs
@@ -31,6 +31,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .Given(step => steps.GivenIHaveSpecfiedAFullMenu())
                 .When(step => steps.WhenICreateTheMenu())
                 .Then(step => steps.ThenTheMenuHasBeenCreated())
+                //.Then(step => steps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/DeleteCategoryTests.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/DeleteCategoryTests.cs
@@ -31,6 +31,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .Then(step => categorySteps.ThenTheCategoryHasBeenCreated())
                 .When(step => categorySteps.WhenIDeleteTheCategory())
                 .Then(step => categorySteps.ThenTheCategoryHasBeenDeleted())
+                //Then(step => steps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/DeleteItemTests.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/DeleteItemTests.cs
@@ -31,6 +31,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .Then(step => itemSteps.ThenTheItemHasBeenCreated())
                 .When(step => itemSteps.WhenIDeleteTheItem())
                 .Then(step => itemSteps.ThenTheItemHasBeenDeleted())
+                //Then(step => itemsteps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/DeleteMenuTests.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/DeleteMenuTests.cs
@@ -29,6 +29,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .And(step => steps.GivenAMenuAlreadyExists())
                 .When(step => steps.WhenIDeleteAMenu())
                 .Then(step => steps.ThenTheMenuHasBeenDeleted())
+                //Then(step => steps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateCategoryById.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateCategoryById.cs
@@ -32,6 +32,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .Then(step => categorySteps.ThenTheCategoryHasBeenCreated())
                 .When(s => categorySteps.WhenISendAnUpdateCategoryRequest())
                 .Then(s => categorySteps.ThenTheCategoryIsUpdatedCorrectly())
+                //Then(step => categorySteps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateItemById.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateItemById.cs
@@ -32,6 +32,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .Then(step => itemSteps.ThenTheItemHasBeenCreated())
                 .When(s => itemSteps.WhenISendAnUpdateItemRequest())
                 .Then(s => itemSteps.ThenTheItemIsUpdatedCorrectly())
+                //Then(step => categorySteps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateItemById.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateItemById.cs
@@ -30,9 +30,9 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .And(step => itemSteps.GivenIHaveSpecfiedAFullItem())
                 .When(step => itemSteps.WhenICreateTheItemForAnExistingMenuAndCategory())
                 .Then(step => itemSteps.ThenTheItemHasBeenCreated())
-                .When(s => itemSteps.WhenISendAnUpdateItemRequest())
-                .Then(s => itemSteps.ThenTheItemIsUpdatedCorrectly())
-                //Then(step => categorySteps.ThenSomeActionIsMade())
+                .When(step => itemSteps.WhenISendAnUpdateItemRequest())
+                .Then(step => itemSteps.ThenTheItemIsUpdatedCorrectly())
+                //Then(step => itemSteps.ThenSomeActionIsMade())
                 //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateMenuById.cs
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/Tests/Stories/UpdateMenuById.cs
@@ -30,6 +30,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.Tests.Functional
                 .And(s => steps.GivenAMenuAlreadyExists())
                 .When(s => steps.WhenISendAnUpdateMenuRequest())
                 .Then(s => steps.ThenTheMenuIsUpdatedCorrectly())
+                //Then(step => categorySteps.ThenSomeActionIsMade())
+                //This step is to verify the outcome of the event in the Subcriber. (e.g. a field is updated in DB, blob is created and so on).
                 .BDDfy();
         }
     }


### PR DESCRIPTION
[XXXX-<Title> - Please use the Work Item number and Title as PR Name, not subtasks]

#### 📲 What
Added an indicative step as commented step to test the action of the events. No actual step is added for functional tests.

#### 🤔 Why
This repo introduces the event pattern. As a purpose of the functional tests is to test the business behaviour and domain-specific event and its consequence (action). As this action is not included, there is no need to add functional tests in this repo.

The commented step indicates the reference for a real project where the event for the domain and its action are implemented and these should be covered in the functional tests.

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
