### PR TITLE
Add query to model mapping in controller

### DIFF
--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.Models/Responses/SearchMenuResponse.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.Models/Responses/SearchMenuResponse.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 
 namespace xxAMIDOxx.xxSTACKSxx.API.Models.Responses
 {
@@ -16,6 +16,6 @@ namespace xxAMIDOxx.xxSTACKSxx.API.Models.Responses
         /// <summary>
         /// Contains the items returned from the search
         /// </summary>
-        public List<SearchMenuResultItem> Results { get; set; }
+        public List<SearchMenuResponseItem> Results { get; set; }
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.Models/Responses/SearchMenuResponseItem.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.Models/Responses/SearchMenuResponseItem.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace xxAMIDOxx.xxSTACKSxx.API.Models.Responses
+{
+    /// <summary>
+    /// Response model representing a search result item in the SearchMenu api endpoint
+    /// </summary>
+    public class SearchMenuResponseItem
+    {
+        /// <example>d290f1ee-6c54-4b01-90e6-d701748f0851</example>
+        public Guid Id { get; set; }
+
+        /// <example>Menu name</example>
+        public string Name { get; set; }
+
+        /// <example>Menu description</example>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// Represents the status of the menu. False if disabled
+        /// </summary>
+        public bool Enabled { get; set; }
+    }
+}

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/Menu/GetMenuByIdController.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/Menu/GetMenuByIdController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 using Amido.Stacks.Application.CQRS.Queries;
 using Microsoft.AspNetCore.Authorization;
@@ -45,7 +46,29 @@ namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
             if (result == null)
                 return NotFound();
 
-            return new ObjectResult(result);
+            var menu = new Menu
+            {
+                Id = result.Id,
+                Name = result.Name,
+                Description = result.Description,
+                Categories = result.Categories.Select(i => new Category()
+                {
+                    Id = i.Id,
+                    Name = i.Name,
+                    Description = i.Description,
+                    Items = i.Items.Select(x => new Item()
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        Description = x.Description,
+                        Price = x.Price,
+                        Available = x.Available
+                    }).ToList(),
+                }).ToList(),
+                Enabled = result.Enabled
+            };
+
+            return new ObjectResult(menu);
         }
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/Menu/SearchMenuController.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/Menu/SearchMenuController.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 using Amido.Stacks.Application.CQRS.Queries;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using xxAMIDOxx.xxSTACKSxx.API.Models.Responses;
 using xxAMIDOxx.xxSTACKSxx.CQRS.Queries.SearchMenu;
 
 namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
@@ -37,7 +39,7 @@ namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
         /// <response code="400">bad request</response>
         [HttpGet("/v1/menu/")]
         [Authorize]
-        [ProducesResponseType(typeof(SearchMenuResult), 200)]
+        [ProducesResponseType(typeof(SearchMenuResponse), 200)]
         public async Task<IActionResult> SearchMenu(
             [FromQuery]string searchTerm, 
             [FromQuery]Guid? RestaurantId, 
@@ -56,7 +58,20 @@ namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
 
             var results = await queryHandler.ExecuteAsync(criteria);
 
-            return new ObjectResult(results); //TOOD: we need a mapping here
+            var response = new SearchMenuResponse()
+            {
+                Offset = (results?.PageNumber ?? 0) * (results?.PageSize ?? 0),
+                Size = (results?.PageSize ?? 0),
+                Results = results.Results.Select(i => new SearchMenuResponseItem()
+                {
+                    Id = i.Id ?? Guid.Empty,
+                    Name = i.Name,
+                    Description = i.Description,
+                    Enabled = i.Enabled ?? false
+                }).ToList()
+            };
+
+            return new ObjectResult(response);
         }
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/EventsTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/EventsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Application.CQRS.Events;
@@ -10,6 +10,7 @@ using NSubstitute;
 using Shouldly;
 using Xunit;
 using xxAMIDOxx.xxSTACKSxx.Common.Events;
+using xxAMIDOxx.xxSTACKSxx.Domain.Events;
 
 namespace xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests
 {
@@ -43,13 +44,13 @@ namespace xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests
 
         public void EventNameShouldMatchOperationName()
         {
-            var definitions = typeof(MenuCreatedEvent).Assembly.GetImplementationsOf(typeof(IApplicationEvent));
+            var definitions = typeof(MenuCreated).Assembly.GetImplementationsOf(typeof(IApplicationEvent));
             foreach (var definition in definitions)
             {
                 var eventCode = GetEventCode(definition.implementation);
                 var eventName = GetEventName(eventCode);
 
-                // If the user intend to use the type as part of the name for convention,
+                // If the user intend to use the type as part of the name for convention, 
                 // the convention should be nameApplicationEvent not nameEvent
                 // Event is generic and can mislead with DomainEvents
                 definition.implementation.Name.ShouldBeOneOf(eventName, $"{eventName}ApplicationEvent");

--- a/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/EventsTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/EventsTests.cs
@@ -10,7 +10,6 @@ using NSubstitute;
 using Shouldly;
 using Xunit;
 using xxAMIDOxx.xxSTACKSxx.Common.Events;
-using xxAMIDOxx.xxSTACKSxx.Domain.Events;
 
 namespace xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests
 {
@@ -44,7 +43,7 @@ namespace xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests
 
         public void EventNameShouldMatchOperationName()
         {
-            var definitions = typeof(MenuCreated).Assembly.GetImplementationsOf(typeof(IApplicationEvent));
+            var definitions = typeof(MenuCreatedEvent).Assembly.GetImplementationsOf(typeof(IApplicationEvent));
             foreach (var definition in definitions)
             {
                 var eventCode = GetEventCode(definition.implementation);
@@ -53,7 +52,7 @@ namespace xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests
                 // If the user intend to use the type as part of the name for convention, 
                 // the convention should be nameApplicationEvent not nameEvent
                 // Event is generic and can mislead with DomainEvents
-                definition.implementation.Name.ShouldBeOneOf(eventName, $"{eventName}ApplicationEvent");
+                definition.implementation.Name.ShouldBeOneOf(eventName, $"{eventName}Event");
             }
         }
 


### PR DESCRIPTION
[XXXX- Add response mapping from query result to model response in controller

#### 📲 What

Currently, the response returned by the controller is q query result model. This change is to map the query result model to a response model in the controller.

#### 🤔 Why

This is required as the existing controller should return a response model.

#### 🕵️ How to test

These changes are covered by existing unit tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
