### PR TITLE
[3492] DevOps - Worker not running in Prod

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -561,7 +561,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -561,7 +561,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -722,6 +722,24 @@ stages:
                       -Z "false"
                   displayName: Promote Listener function Docker Image to Production ACR
 
+                - task: Bash@3
+                  inputs:
+                    filePath: "$(self_pipeline_scripts_dir)/util-azure-promote-image.bash"
+                    arguments: >
+                      -a "$(docker_bg_worker_image_name):$(docker_image_tag)"
+                      -b "$(k8s_docker_registry_nonprod)"
+                      -c "$(azure-subscription-id)"
+                      -d "$(azure-client-id)"
+                      -e "$(azure-client-secret)"
+                      -f "$(azure-tenant-id)"
+                      -g "$(k8s_docker_registry_prod)"
+                      -h "$(prod-azure-subscription-id)"
+                      -i "$(prod-azure-client-id)"
+                      -j "$(prod-azure-client-secret)"
+                      -k "$(prod-azure-tenant-id)"
+                      -Z "false"
+                  displayName: Promote BG worker Docker Image to Production ACR                  
+
       - deployment: DeployProd
         dependsOn:
           - AppInfraProd

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -738,7 +738,7 @@ stages:
                       -j "$(prod-azure-client-secret)"
                       -k "$(prod-azure-tenant-id)"
                       -Z "false"
-                  displayName: Promote BG worker Docker Image to Production ACR                  
+                  displayName: Promote BG worker Docker Image to Production ACR
 
       - deployment: DeployProd
         dependsOn:


### PR DESCRIPTION
#### 📲 What

Promote the BG worker image from the nonprod container registry to the production one

#### 🤔 Why

Without the image in the production container registry it cannot be deployed into the Prod kubernetes cluster

#### 🛠 How

Added a new step to perform the promotion

#### 👀 Evidence

The image for the BG worker is now in the prod container

![image](https://user-images.githubusercontent.com/791658/131986413-58d11802-925a-4f1c-b5f9-9c884401d051.png)

The deployment of the application into Kubernetes is successful

![image](https://user-images.githubusercontent.com/791658/131986508-b0ca2ff9-599e-42e9-9bd5-563221078188.png)

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
