### PR TITLE
Add event hub publisher to API

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -107,6 +107,8 @@
 				{
 					"condition": "(!enableFunctionListener)",
 					"exclude": [
+						"**/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/**",
+						"**/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/**",
 						"**/src/functions/function-listener/xxAMIDOxx.xxSTACKSxx.Listener/**",
 						"**/src/functions/function-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/**"
 					]

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -114,6 +114,20 @@
 					]
 				},
 				{
+					"condition": "(enableFunctionListener && EventPublisherServiceBus)",
+					"exclude": [
+						"**/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/**",
+						"**/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/**"
+					]
+				},
+				{
+					"condition": "(enableFunctionListener && EventPublisherEventHub)",
+					"exclude": [
+						"**/src/functions/function-listener/xxAMIDOxx.xxSTACKSxx.Listener/**",
+						"**/src/functions/function-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/**"
+					]
+				},
+				{
 					"condition": "(!enableFunctionListener && !enableFunctionWorker)",
 					"exclude": [
 						"**/src/functions/**",

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -154,5 +154,23 @@
 				}
 			]
 		}
-	}
+	},
+	"postActions": [
+		{
+			"Description": "Adding Reference to Amido.Stacks.Messaging.Azure.ServiceBus NuGet package",
+			"actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
+			"ContinueOnError": "false",
+			"manualInstructions": [
+				{
+					"text": "Manually add the reference to Amido.Stacks.Messaging.Azure.ServiceBus to your project file"
+				}
+			],
+			"args": {
+				"referenceType": "package",
+				"reference": "Amido.Stacks.Messaging.Azure.ServiceBus",
+				"version": "0.2.8",
+				"projectFileExtensions": ".csproj"
+			}
+		}
+	]	  
 }

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -132,6 +132,12 @@
 					"exclude": [
 						"**/src/worker/**"
 					]
+				},
+				{
+					"condition": "EventPublisherServiceBus || EventPublisherEventHub",
+					"exclude": [
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Fakes/DummyEventPublisher.cs"
+					]
 				}
 			]
 		}

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -43,13 +43,8 @@
 				{
 					"choice": "EventHub",
 					"description": "Targets the Azure Event Hub for publishing events."
-				},
-				{
-					"choice": "None",
-					"description": "No event publishing added."
 				}
 			],
-			"defaultValue": "None",
 			"description": "Adds event publishing."
 		},
 		"EventPublisherServiceBus": {
@@ -59,10 +54,6 @@
 		"EventPublisherEventHub": {
 			"type": "computed",
 			"value": "(eventPublisher == \"EventHub\")"
-		},
-		"EventPublisherNone": {
-			"type": "computed",
-			"value": "(eventPublisher == \"None\")"
 		},
 		"enableFunctionWorker": {
 			"type": "parameter",

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -32,6 +32,38 @@
 				]
 			}
 		},
+		"eventPublisher": {
+			"type": "parameter",
+			"datatype": "choice",
+			"choices": [
+				{
+					"choice": "ServiceBus",
+					"description": "Targets the Azure Service Bus for publishing events."
+				},
+				{
+					"choice": "EventHub",
+					"description": "Targets the Azure Event Hub for publishing events."
+				},
+				{
+					"choice": "None",
+					"description": "No event publishing added."
+				}
+			],
+			"defaultValue": "None",
+			"description": "Adds event publishing."
+		},
+		"EventPublisherServiceBus": {
+			"type": "computed",
+			"value": "(eventPublisher == \"ServiceBus\")"
+		},
+		"EventPublisherEventHub": {
+			"type": "computed",
+			"value": "(eventPublisher == \"EventHub\")"
+		},
+		"EventPublisherNone": {
+			"type": "computed",
+			"value": "(eventPublisher == \"None\")"
+		},
 		"enableFunctionWorker": {
 			"type": "parameter",
 			"dataType": "bool",

--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -154,23 +154,5 @@
 				}
 			]
 		}
-	},
-	"postActions": [
-		{
-			"Description": "Adding Reference to Amido.Stacks.Messaging.Azure.ServiceBus NuGet package",
-			"actionId": "B17581D1-C5C9-4489-8F0A-004BE667B814",
-			"ContinueOnError": "false",
-			"manualInstructions": [
-				{
-					"text": "Manually add the reference to Amido.Stacks.Messaging.Azure.ServiceBus to your project file"
-				}
-			],
-			"args": {
-				"referenceType": "package",
-				"reference": "Amido.Stacks.Messaging.Azure.ServiceBus",
-				"version": "0.2.8",
-				"projectFileExtensions": ".csproj"
-			}
-		}
-	]	  
+	}
 }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ stacks-dotnet-cqrs-events
     - `Worker` is a CosmosDB change feed trigger function that publishes a `CosmosDbChangeFeedEvent` when a new entity has been added or was changed to CosmosDB
 - The `worker` folder contains a background worker that listens to all event types from the ASB topic and shows example handlers for them and the use of the [Amido.Stacks.Messaging.Azure.ServiceBus](https://github.com/amido/stacks-dotnet-packages-messaging-asb) package.
 
-The API, functions and worker all depend on the [Amido.Stacks.Messaging.Azure.ServiceBus](https://github.com/amido/stacks-dotnet-packages-messaging-asb) package for their communication with ASB.
+The API, functions and worker all depend on the [Amido.Stacks.Messaging.Azure.ServiceBus](https://github.com/amido/stacks-dotnet-packages-messaging-asb) and the [Amido.Stacks.Messaging.Azure.EventHub](https://github.com/amido/stacks-dotnet-packages-messaging-aeh) packages for their communication with Azure Service Bus or Azure Event Hub depending on the specific implementation.
 
 The functions and workers are all stand-alone implementations that can be used together or separately in different projects.
 
@@ -199,6 +199,10 @@ To run the API locally on MacOS there are a couple of prerequisites that you hav
 
 You'll need an Azure Service Bus namespace and a topic with subscriber in order to be able to publish application events.
 
+#### Azure Service Bus
+
+You'll will need an Azure Event Hub namespace and an Event Hub to publish application events. You will also need a blob container storage account.
+
 #### Configuring CosmosDB and ServiceBus
 
 Now that you have your CosmosDB all set, you can point the API project to it. In `appsettings.json` you can see the following sections
@@ -252,6 +256,25 @@ To set the environment variables permanently on your system you'll have to edit 
 # Example for setting env variable in .zchenv
 echo 'export COSMOSDB_KEY=YOUR_COSMOSDB_PRIMARY_KEY' >> ~/.zshenv
 echo 'export SERVICEBUS_CONNECTIONSTRING=YOUR_SERVICE_BUS_CONNECTION_STRING' >> ~/.zshenv
+```
+
+#### Configuring EventHub
+
+In `appsettings.json` you can see the following sections to configure Event Hub
+
+```json
+"EventHubConfiguration": {
+    "Publisher": {
+      "EventHubNamespaceConnectionString": "",
+      "EventHubName": ""
+    },
+    "Consumer": {
+      "EventHubNamespaceConnectionString": "",
+      "EventHubName": "",
+      "BlobStorageConnectionString": "",
+      "BlobContainerName": ""
+    }
+}
 ```
 
 ### Running the Worker ChangeFeed listener locally

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Windows Forms (WinForms) Class library           winformslib                    
 Worker Service                                   worker                           [C#],F#     Common/Worker/Web
 Amido Stacks Azure Function CosmosDb Worker      stacks-function-cosmosdb-worker  [C#]        Stacks/Azure Function/CosmosDb/Worker
 Amido Stacks Azure Function Service Bus Trigger  stacks-function-asb-listener     [C#]        Stacks/Azure Function/Service Bus/Listener
-Amido Stacks Azure Function Event Hub Trigger    stacks-function-aeh-listener     [C#]        Stacks/Azure Function/Event Hub/Listener
+Amido Stacks Azure Function Event Hub Trigger    stacks-azfunc-aeh-listener       [C#]        Stacks/Azure Function/Event Hub/Listener
 Amido Stacks Service Bus Worker                  stacks-app-asb-worker            [C#]        Stacks/Service Bus/Worker
 Amido Stacks CQRS Events WebAPI                  stacks-api-cqrs-events           [C#]        Stacks/WebAPI/CQRS/Events
 Amido Stacks CQRS Events                         stacks-app-cqrs-events           [C#]        Stacks/WebAPI/Infrastructure/CQRS/Events

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ To run the API locally on MacOS there are a couple of prerequisites that you hav
 
 You'll need an Azure Service Bus namespace and a topic with subscriber in order to be able to publish application events.
 
-#### Azure Service Bus
+#### Azure Event Hub
 
 You'll will need an Azure Event Hub namespace and an Event Hub to publish application events. You will also need a blob container storage account.
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ All templates from this repository come as part of the [Amido.Stacks.CQRS.Events
 - `stacks-api-cqrs-events`. A template for the `api` project. If you need a CQRS WebAPI that can publish messages to ServiceBus, this is the template to use.
 - `stacks-app-asb-worker`. This template contains a background worker application that reads and handles messages from a ServiceBus subscription.
 - `stacks-function-asb-listener`. Template containing an Azure Function project with a single function that has a Service Bus subscription trigger. The function receives the message and deserializes it.
+- `stacks-function-aeh-listener`. Template containing an Azure Function project with a single function that has a Event Hub trigger. The function receives the message and deserializes it.
 - `stacks-function-cosmosdb-worker`. Azure Function containing a CosmosDb change feed trigger. Upon a CosmosDb event, the worker reads it and publishes a message to Service Bus.
-
 
 ### Template usage
 
@@ -68,6 +68,7 @@ Windows Forms (WinForms) Class library           winformslib                    
 Worker Service                                   worker                           [C#],F#     Common/Worker/Web
 Amido Stacks Azure Function CosmosDb Worker      stacks-function-cosmosdb-worker  [C#]        Stacks/Azure Function/CosmosDb/Worker
 Amido Stacks Azure Function Service Bus Trigger  stacks-function-asb-listener     [C#]        Stacks/Azure Function/Service Bus/Listener
+Amido Stacks Azure Function Event Hub Trigger    stacks-function-aeh-listener     [C#]        Stacks/Azure Function/Event Hub/Listener
 Amido Stacks Service Bus Worker                  stacks-app-asb-worker            [C#]        Stacks/Service Bus/Worker
 Amido Stacks CQRS Events WebAPI                  stacks-api-cqrs-events           [C#]        Stacks/WebAPI/CQRS/Events
 Amido Stacks CQRS Events                         stacks-app-cqrs-events           [C#]        Stacks/WebAPI/Infrastructure/CQRS/Events

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.8"/>
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.10"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.API\xxAMIDOxx.xxSTACKSxx.API.csproj"/>

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
@@ -1,64 +1,76 @@
 ﻿{
-	"Serilog": {
-		"Using": [
-			"Serilog.Sinks.Console",
-			"Serilog.Sinks.ApplicationInsights"
-		],
-		"MinimumLevel": {
-			"Default": "Debug",
-			"Override": {}
-		},
-		"WriteTo": [
-			{
-				"Name": "Console"
-			},
-			{
-				"Name": "ApplicationInsights",
-				"Args": {
-					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-				}
-			}
-		],
-		"Enrich": [
-			"FromLogContext",
-			"WithMachineName",
-			"WithThreadId"
-		],
-		"Destructure": [],
-		"Properties": {
-			"Application": "Menu API"
-		}
-	},
-	"AllowedHosts": "*",
+    "Serilog": {
+        "Using": [
+            "Serilog.Sinks.Console",
+            "Serilog.Sinks.ApplicationInsights"
+        ],
+        "MinimumLevel": {
+            "Default": "Debug",
+            "Override": {}
+        },
+        "WriteTo": [
+            {
+                "Name": "Console"
+            },
+            {
+                "Name": "ApplicationInsights",
+                "Args": {
+                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+                }
+            }
+        ],
+        "Enrich": [
+            "FromLogContext",
+            "WithMachineName",
+            "WithThreadId"
+        ],
+        "Destructure": [],
+        "Properties": {
+            "Application": "Menu API"
+        }
+    },
+    "AllowedHosts": "*",
     "CosmosDb": {
-        "DatabaseAccountUri": "https://amido-stacks-dev-euw-netcore-api-cqrs-evnts.documents.azure.com:443/",
-        "DatabaseName": "amido-stacks-dev-euw-netcore-api-cqrs-evnts",
+        "DatabaseAccountUri": "https://localhost:8081/",
+        "DatabaseName": "Stacks",
         "SecurityKeySecret": {
             "Identifier": "COSMOSDB_KEY",
             "Source": "Environment"
         }
     },
-	"JwtBearerAuthentication": {
-		"Audience": "<TODO>",
-		"Authority": "<TODO>",
-		"Enabled": false,
-		"OpenApi": {
-			"AuthorizationUrl": "<TODO>",
-			"ClientId": "<TODO>",
-			"TokenUrl": "<TODO>"
-		}
-	},
-	"ServiceBusConfiguration": {
-		"Sender": {
-			"Topics": [
-				{
-					"Name": "sbt-menu-events",
+    "JwtBearerAuthentication": {
+        "Audience": "<TODO>",
+        "Authority": "<TODO>",
+        "Enabled": false,
+        "OpenApi": {
+            "AuthorizationUrl": "<TODO>",
+            "ClientId": "<TODO>",
+            "TokenUrl": "<TODO>"
+        }
+    },
+    "ServiceBusConfiguration": {
+        "Sender": {
+            "Topics": [
+                {
+                    "Name": "sbt-menu-events",
                     "ConnectionStringSecret": {
                         "Identifier": "SERVICEBUS_CONNECTIONSTRING",
                         "Source": "Environment"
                     }
-				}
-			]
-		}
-	}
+                }
+            ]
+        }
+    },
+    "EventHubConfiguration": {
+        "Publisher": {
+            "EventHubNamespaceConnectionString": "",
+            "EventHubName": ""
+        },
+        "Consumer": {
+            "EventHubNamespaceConnectionString": "",
+            "EventHubName": "",
+            "BlobStorageConnectionString": "",
+            "BlobContainerName": ""
+        }
+    }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Application.CQRS.Commands;
 using Amido.Stacks.Application.CQRS.Queries;
 using Amido.Stacks.Configuration.Extensions;
@@ -47,15 +46,15 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
 #if (EventPublisherServiceBus)
             services.Configure<Amido.Stacks.Messaging.Azure.ServiceBus.Configuration.ServiceBusConfiguration>(context.Configuration.GetSection("ServiceBusConfiguration"));
             services.AddServiceBus();
-            services.AddTransient<IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.ServiceBus.Senders.Publishers.EventPublisher>();
+            services.AddTransient<Amido.Stacks.Application.CQRS.ApplicationEvents.IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.ServiceBus.Senders.Publishers.EventPublisher>();
 #endif
 #if (EventPublisherEventHub)
             services.Configure<Amido.Stacks.Messaging.Azure.EventHub.Configuration.EventHubConfiguration>(context.Configuration.GetSection("EventHubConfiguration"));
             services.AddEventHub();
-            services.AddTransient<IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.EventHub.Publisher.EventPublisher>();
+            services.AddTransient<Amido.Stacks.Application.CQRS.ApplicationEvents.IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.EventHub.Publisher.EventPublisher>();
 #endif
 #if (EventPublisherNone)
-            services.AddTransient<IApplicationEventPublisher, DummyEventPublisher>();
+            services.AddTransient<Amido.Stacks.Application.CQRS.ApplicationEvents.IApplicationEventPublisher, DummyEventPublisher>();
 #endif
 
             if (Environment.GetEnvironmentVariable("USE_MEMORY_STORAGE") == null)

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -48,13 +48,11 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
             services.Configure<Amido.Stacks.Messaging.Azure.ServiceBus.Configuration.ServiceBusConfiguration>(context.Configuration.GetSection("ServiceBusConfiguration"));
             services.AddServiceBus();
             services.AddTransient<IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.ServiceBus.Senders.Publishers.EventPublisher>();
-#endif
-#if (EventPublisherEventHub)
+#elif (EventPublisherEventHub)
             services.Configure<Amido.Stacks.Messaging.Azure.EventHub.Configuration.EventHubConfiguration>(context.Configuration.GetSection("EventHubConfiguration"));
             services.AddEventHub();
             services.AddTransient<IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.EventHub.Publisher.EventPublisher>();
-#endif
-#if (EventPublisherNone)
+#else
             services.AddTransient<IApplicationEventPublisher, DummyEventPublisher>();
 #endif
 

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Application.CQRS.Commands;
 using Amido.Stacks.Application.CQRS.Queries;
 using Amido.Stacks.Configuration.Extensions;
@@ -46,15 +47,15 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
 #if (EventPublisherServiceBus)
             services.Configure<Amido.Stacks.Messaging.Azure.ServiceBus.Configuration.ServiceBusConfiguration>(context.Configuration.GetSection("ServiceBusConfiguration"));
             services.AddServiceBus();
-            services.AddTransient<Amido.Stacks.Application.CQRS.ApplicationEvents.IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.ServiceBus.Senders.Publishers.EventPublisher>();
+            services.AddTransient<IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.ServiceBus.Senders.Publishers.EventPublisher>();
 #endif
 #if (EventPublisherEventHub)
             services.Configure<Amido.Stacks.Messaging.Azure.EventHub.Configuration.EventHubConfiguration>(context.Configuration.GetSection("EventHubConfiguration"));
             services.AddEventHub();
-            services.AddTransient<Amido.Stacks.Application.CQRS.ApplicationEvents.IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.EventHub.Publisher.EventPublisher>();
+            services.AddTransient<IApplicationEventPublisher, Amido.Stacks.Messaging.Azure.EventHub.Publisher.EventPublisher>();
 #endif
 #if (EventPublisherNone)
-            services.AddTransient<Amido.Stacks.Application.CQRS.ApplicationEvents.IApplicationEventPublisher, DummyEventPublisher>();
+            services.AddTransient<IApplicationEventPublisher, DummyEventPublisher>();
 #endif
 
             if (Environment.GetEnvironmentVariable("USE_MEMORY_STORAGE") == null)

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -89,16 +89,5 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
                 services.AddTransient(definition.interfaceVariation, definition.implementation);
             }
         }
-
-        private static void AddEventPublishers(IServiceCollection services)
-        {
-            log.Information("Loading implementations of {interface}", typeof(IApplicationEventPublisher).Name);
-            var definitions = typeof(DummyEventPublisher).Assembly.GetImplementationsOf(typeof(IApplicationEventPublisher));
-            foreach (var definition in definitions)
-            {
-                log.Information("Registering '{implementation}' as implementation of '{interface}'", definition.implementation.FullName, definition.interfaceVariation.FullName);
-                services.AddTransient(definition.interfaceVariation, definition.implementation);
-            }
-        }
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.15" />
 	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.8"/>
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.0-preview-master" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -7,8 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.15" />
-	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.8"/>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.0-preview-master" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -7,6 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Amido.Stacks.Data.Documents.CosmosDB" Version="0.2.15" />
+	<PackageReference Include="Amido.Stacks.Messaging.Azure.ServiceBus" Version="0.2.8"/>
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.0-preview-master" />
     <PackageReference Include="Amido.Stacks.DependencyInjection" Version="0.2.17" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />

--- a/src/functions/func-aeh-listener/.editorconfig
+++ b/src/functions/func-aeh-listener/.editorconfig
@@ -1,0 +1,123 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+############################### 
+# Core EditorConfig Options   # 
+############################### 
+# All files 
+[*] 
+indent_style = space 
+end_of_line = lf
+indent_size = 4 
+insert_final_newline = true 
+charset = utf-8-bom 
+
+############################### 
+# .NET Coding Conventions     # 
+############################### 
+[*.{cs,vb}] 
+# Organize usings 
+dotnet_sort_system_directives_first = true 
+# this. preferences 
+dotnet_style_qualification_for_field = false:silent 
+dotnet_style_qualification_for_property = false:silent 
+dotnet_style_qualification_for_method = false:silent 
+dotnet_style_qualification_for_event = false:silent 
+# Language keywords vs BCL types preferences 
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent 
+dotnet_style_predefined_type_for_member_access = true:silent 
+# Parentheses preferences 
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent 
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent 
+# Modifier preferences 
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent 
+dotnet_style_readonly_field = true:suggestion 
+# Expression-level preferences 
+dotnet_style_object_initializer = true:suggestion 
+dotnet_style_collection_initializer = true:suggestion 
+dotnet_style_explicit_tuple_names = true:suggestion 
+dotnet_style_null_propagation = true:suggestion 
+dotnet_style_coalesce_expression = true:suggestion 
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent 
+dotnet_prefer_inferred_tuple_names = true:suggestion 
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion 
+dotnet_style_prefer_auto_properties = true:silent 
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent 
+dotnet_style_prefer_conditional_expression_over_return = true:silent 
+############################### 
+# Naming Conventions          # 
+############################### 
+# Style Definitions 
+dotnet_naming_style.pascal_case_style.capitalization             = pascal_case 
+# Use PascalCase for constant fields   
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields 
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style 
+dotnet_naming_symbols.constant_fields.applicable_kinds            = field 
+dotnet_naming_symbols.constant_fields.applicable_accessibilities  = * 
+dotnet_naming_symbols.constant_fields.required_modifiers          = const 
+############################### 
+# C# Coding Conventions       # 
+############################### 
+[*.cs] 
+# var preferences 
+csharp_style_var_for_built_in_types = true:silent 
+csharp_style_var_when_type_is_apparent = true:silent 
+csharp_style_var_elsewhere = true:silent 
+# Expression-bodied members 
+csharp_style_expression_bodied_methods = false:silent 
+csharp_style_expression_bodied_constructors = false:silent 
+csharp_style_expression_bodied_operators = false:silent 
+csharp_style_expression_bodied_properties = true:silent 
+csharp_style_expression_bodied_indexers = true:silent 
+csharp_style_expression_bodied_accessors = true:silent 
+# Pattern matching preferences 
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion 
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion 
+# Null-checking preferences 
+csharp_style_throw_expression = true:suggestion 
+csharp_style_conditional_delegate_call = true:suggestion 
+# Modifier preferences 
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion 
+# Expression-level preferences 
+csharp_prefer_braces = true:silent 
+csharp_style_deconstructed_variable_declaration = true:suggestion 
+csharp_prefer_simple_default_expression = true:suggestion 
+csharp_style_pattern_local_over_anonymous_function = true:suggestion 
+csharp_style_inlined_variable_declaration = true:suggestion 
+############################### 
+# C# Formatting Rules         # 
+############################### 
+# New line preferences 
+csharp_new_line_before_open_brace = all 
+csharp_new_line_before_else = true 
+csharp_new_line_before_catch = true 
+csharp_new_line_before_finally = true 
+csharp_new_line_before_members_in_object_initializers = true 
+csharp_new_line_before_members_in_anonymous_types = true 
+csharp_new_line_between_query_expression_clauses = true 
+# Indentation preferences 
+csharp_indent_case_contents = true 
+csharp_indent_switch_labels = true 
+csharp_indent_labels = flush_left 
+# Space preferences 
+csharp_space_after_cast = false 
+csharp_space_after_keywords_in_control_flow_statements = true 
+csharp_space_between_method_call_parameter_list_parentheses = false 
+csharp_space_between_method_declaration_parameter_list_parentheses = false 
+csharp_space_between_parentheses = false 
+csharp_space_before_colon_in_inheritance_clause = true 
+csharp_space_after_colon_in_inheritance_clause = true 
+csharp_space_around_binary_operators = before_and_after 
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false 
+csharp_space_between_method_call_name_and_opening_parenthesis = false 
+csharp_space_between_method_call_empty_parameter_list_parentheses = false 
+# Wrapping preferences 
+csharp_preserve_single_line_statements = true 
+csharp_preserve_single_line_blocks = true 
+############################### 
+# VB Coding Conventions       # 
+############################### 
+[*.vb] 
+# Modifier preferences 
+visual_basic_preferred_modifier_order = Partial,Default,Private,Protected,Public,Friend,NotOverridable,Overridable,MustOverride,Overloads,Overrides,MustInherit,NotInheritable,Static,Shared,Shadows,ReadOnly,WriteOnly,Dim,Const,WithEvents,Widening,Narrowing,Custom,Async:suggestion 

--- a/src/functions/func-aeh-listener/.template.config/template.json
+++ b/src/functions/func-aeh-listener/.template.config/template.json
@@ -1,0 +1,62 @@
+﻿{
+    "$schema": "http://json.schemastore.org/template",
+    "author": "stacks@amido.com",
+    "classifications": [
+        "Stacks",
+        "Azure Function",
+        "Event Hub",
+        "Listener"
+    ],
+    "name": "Amido Stacks Azure Function Event Hub Trigger",
+    "identity": "Amido.Stacks.Function.EventHub.Listener.CSharp",
+    "groupIdentity": "Amido.Stacks.Function.Listener",
+    "shortName": "stacks-function-aeh-listener",
+    "tags": {
+        "language": "C#",
+        "type": "project"
+    },
+    "sourceName": "xxAMIDOxx.xxSTACKSxx",
+    "preferNameDirectory": true,
+    "symbols": {},
+    "sources": [
+        {
+            "source": "./",
+            "include": [
+                "**/*"
+            ],
+            "exclude": [
+                "**/[Bb]in/**",
+                "**/[Oo]bj/**",
+                "**/.template.config/**",
+                "**/*.filelist",
+                "**/*.user",
+                "**/*.lock.json",
+                "**/.git/**",
+                "**/.vs/**",
+                "**/.vscode/**",
+                "_rels/**",
+                "package/**",
+                "**/*.nuspec",
+                "*Content_Types*.xml"
+            ],
+            "rename": {
+                "_gitignore": ".gitignore",
+                "_gitattributes": ".gitattributes"
+            },
+            "modifiers": []
+        }
+    ],
+    "SpecialCustomOperations": {
+        "**/*.yml": {
+            "Operations": [
+                {
+                    "type": "conditional",
+                    "configuration": {
+                        "style": "line",
+                        "token": "#"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/src/functions/func-aeh-listener/.template.config/template.json
+++ b/src/functions/func-aeh-listener/.template.config/template.json
@@ -8,9 +8,9 @@
         "Listener"
     ],
     "name": "Amido Stacks Azure Function Event Hub Trigger",
-    "identity": "Amido.Stacks.Function.EventHub.Listener.CSharp",
-    "groupIdentity": "Amido.Stacks.Function.Listener",
-    "shortName": "stacks-function-aeh-listener",
+    "identity": "Amido.Stacks.AzFunc.EventHub.Listener.CSharp",
+    "groupIdentity": "Amido.Stacks.AzFunc.EventHub.Listener",
+    "shortName": "stacks-azfunc-aeh-listener",
     "tags": {
         "language": "C#",
         "type": "project"

--- a/src/functions/func-aeh-listener/Dockerfile
+++ b/src/functions/func-aeh-listener/Dockerfile
@@ -1,0 +1,23 @@
+# Dockefile to create an image for either of the functions
+#
+# To build it, a function name needs to be passed in as an argument to the build.
+# For example:
+#
+# docker build -t stacks-dotnet-cqrs-events --build-arg function=xxAMIDOxx.xxSTACKSxx.Listener .\src\functions
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1 as build
+
+ARG function
+ARG outdir=out
+
+WORKDIR /app
+
+# Copy the worker project and build
+COPY ./${function} ./${function}
+RUN dotnet publish -c Release -o ${outdir} ${function}
+
+# Build the runtime image
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0 as runtime
+EXPOSE 80
+WORKDIR /home/site/wwwroot
+COPY --from=build /app/${outdir} .

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Amido.Stacks.Application.CQRS.Events;
+using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using NSubstitute;
+using Xunit;
+
+namespace xxAMIDOxx.xxSTACKSxx.Listener.UnitTests
+{
+    [Trait("TestType", "UnitTests")]
+    public class StacksListenerTests
+    {
+        private readonly IMessageReader msgReader;
+        private readonly ILogger<StacksListener> logger;
+
+        public StacksListenerTests()
+        {
+            msgReader = Substitute.For<IMessageReader>();
+            logger = Substitute.For<ILogger<StacksListener>>();
+        }
+
+        [Fact]
+        public void TestExecution()
+        {
+            var eventData = new List<EventData>();
+
+            var msgBody = BuildMessageBody();
+            var message = BuildEventData(msgBody);
+
+            eventData.Add(message);
+
+            var stacksListener = new StacksListener(msgReader, logger);
+
+            stacksListener.Run(eventData.ToArray());
+
+            msgReader.Received(1).Read<MenuCreatedEvent>(message);
+        }
+
+        public MenuCreatedEvent BuildMessageBody()
+        {
+            var id = Guid.NewGuid();
+            return new MenuCreatedEvent(new TestOperationContext(), id);
+        }
+
+        public EventData BuildEventData(MenuCreatedEvent body)
+        {
+            var byteArray = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(body));
+
+            var eventData = new EventData(byteArray);
+
+            return eventData;
+        }
+    }
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/TestOperationContext.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/TestOperationContext.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Amido.Stacks.Core.Operations;
+
+namespace xxAMIDOxx.xxSTACKSxx.Listener.UnitTests
+{
+    public class TestOperationContext : IOperationContext
+    {
+        public TestOperationContext() { }
+
+        public int OperationCode => 999;
+
+        public Guid CorrelationId => Guid.NewGuid();
+    }
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+            <LangVersion>7.3</LangVersion>
+        <IsPackable>false</IsPackable>    <LangVersion>7.3</LangVersion>
+    
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Listener\xxAMIDOxx.xxSTACKSxx.Listener.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.1-preview-master" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.2-preview-master" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -8,12 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.1-preview-master" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="3.1.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.sln
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31624.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xxAMIDOxx.xxSTACKSxx.Listener.UnitTests", "xxAMIDOxx.xxSTACKSxx.Listener.UnitTests\xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj", "{58BE3948-BD18-4565-9F55-8C8C6C933F40}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xxAMIDOxx.xxSTACKSxx.Listener", "xxAMIDOxx.xxSTACKSxx.Listener\xxAMIDOxx.xxSTACKSxx.Listener.csproj", "{F0D1F96E-DAB7-40F0-B976-3743A2BB672E}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{58BE3948-BD18-4565-9F55-8C8C6C933F40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{58BE3948-BD18-4565-9F55-8C8C6C933F40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{58BE3948-BD18-4565-9F55-8C8C6C933F40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{58BE3948-BD18-4565-9F55-8C8C6C933F40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0D1F96E-DAB7-40F0-B976-3743A2BB672E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0D1F96E-DAB7-40F0-B976-3743A2BB672E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0D1F96E-DAB7-40F0-B976-3743A2BB672E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0D1F96E-DAB7-40F0-B976-3743A2BB672E}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C834AE26-AF25-4F73-A96E-7DEBC581E864}
+	EndGlobalSection
+EndGlobal

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/Logging/LogAdapter.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/Logging/LogAdapter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace xxAMIDOxx.xxSTACKSxx.Listener.Logging
+{
+    /// <summary>
+    ///     Allow use of ILogger<> at dependency registration level
+    ///     Required to bypass issue with Azure Function DI not registering
+    ///     logging dependencies soon enough
+    /// </summary>
+    public class LogAdapter<T> : ILogger<T>
+    {
+        private readonly Lazy<ILogger> logger;
+
+        public LogAdapter(ILoggerProvider provider) =>
+            logger = new Lazy<ILogger>(() => provider.CreateLogger(typeof(T).Name));
+
+        public IDisposable BeginScope<TState>(TState state) => logger.Value.BeginScope(state);
+
+        public bool IsEnabled(LogLevel logLevel) => logger.Value.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception exception,
+            Func<TState, Exception, string> formatter
+        ) => logger.Value.Log(logLevel, eventId, state, exception, formatter);
+    }
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Amido.Stacks.Application.CQRS.Events;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace xxAMIDOxx.xxSTACKSxx.Listener
+{
+    // TODO: Move this to https://github.com/amido/stacks-dotnet-packages-messaging-aeh
+    public interface IMessageReader
+    {
+        T Read<T>(EventData eventData);
+    }
+
+    // TODO: Move this to https://github.com/amido/stacks-dotnet-packages-messaging-aeh
+    public class JsonMessageSerializer : IMessageReader
+    {
+        public T Read<T>(EventData eventData)
+        {
+            var jsonBody = Encoding.UTF8.GetString(eventData.Body);
+            return JsonConvert.DeserializeObject<T>(jsonBody);
+        }
+    }
+
+    public class StacksListener
+    {
+        private readonly IMessageReader msgReader;
+        private readonly ILogger<StacksListener> logger;
+
+        public StacksListener(IMessageReader msgReader, ILogger<StacksListener> logger)
+        {
+            this.msgReader = msgReader;
+            this.logger = logger;
+        }
+
+        [FunctionName("StacksListener")]
+        public void Run([EventHubTrigger(
+            "%EVENTHUB_NAME%",
+            Connection = "EVENTHUB_CONNECTIONSTRING")] EventData[] events)
+        {
+            var exceptions = new List<Exception>();
+
+            foreach (EventData eventData in events)
+            {
+                try
+                {
+                    var appEvent = msgReader.Read<MenuCreatedEvent>(eventData);
+                    logger.LogInformation($"Message read. Menu Id: {appEvent?.MenuId}");
+                    logger.LogInformation($"C# Event Hub trigger function processed an event: {appEvent}");
+                }
+                catch (Exception e)
+                {
+                    exceptions.Add(e);
+                }
+            }
+
+            if (exceptions.Count > 1)
+                throw new AggregateException(exceptions);
+
+            if (exceptions.Count == 1)
+                throw exceptions.Single();
+        }
+    }
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
@@ -1,31 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Amido.Stacks.Application.CQRS.Events;
+using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 
 namespace xxAMIDOxx.xxSTACKSxx.Listener
 {
-    // TODO: Move this to https://github.com/amido/stacks-dotnet-packages-messaging-aeh
-    public interface IMessageReader
-    {
-        T Read<T>(EventData eventData);
-    }
-
-    // TODO: Move this to https://github.com/amido/stacks-dotnet-packages-messaging-aeh
-    public class JsonMessageSerializer : IMessageReader
-    {
-        public T Read<T>(EventData eventData)
-        {
-            var jsonBody = Encoding.UTF8.GetString(eventData.Body);
-            return JsonConvert.DeserializeObject<T>(jsonBody);
-        }
-    }
-
     public class StacksListener
     {
         private readonly IMessageReader msgReader;

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/Startup.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/Startup.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Serilog;
+using Serilog.Core;
+using xxAMIDOxx.xxSTACKSxx.Listener;
+using xxAMIDOxx.xxSTACKSxx.Listener.Logging;
+
+[assembly: FunctionsStartup(typeof(Startup))]
+namespace xxAMIDOxx.xxSTACKSxx.Listener
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            RegisterDependentServices(builder);
+
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver()
+            };
+        }
+
+        protected virtual void RegisterDependentServices(IFunctionsHostBuilder builder)
+        {
+            var configuration = LoadConfiguration(builder);
+
+            builder.Services
+                .Configure<StacksListener>(configuration.GetSection(nameof(StacksListener)))
+                .AddLogging(l => { l.AddSerilog(CreateLogger(configuration)); })
+                .AddTransient(typeof(ILogger<>), typeof(LogAdapter<>));
+
+            builder.Services.AddTransient<IMessageReader, JsonMessageSerializer>();
+        }
+
+        private static IConfiguration LoadConfiguration(IFunctionsHostBuilder builder)
+        {
+            return new ConfigurationBuilder()
+                .SetBasePath(builder.GetContext().ApplicationRootPath)
+                .AddJsonFile("appsettings.json", false)
+                .AddEnvironmentVariables()
+                .Build();
+        }
+
+        private static Logger CreateLogger(IConfiguration config)
+        {
+            return new LoggerConfiguration()
+                .ReadFrom
+                .Configuration(config)
+                .CreateLogger();
+        }
+    }
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/Startup.cs
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+﻿using Amido.Stacks.Messaging.Azure.EventHub.Serializers;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/appsettings.json
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/appsettings.json
@@ -1,0 +1,28 @@
+{
+	"Serilog": {
+		"Using": [
+			"Serilog.Sinks.Console",
+			"Serilog.Sinks.ApplicationInsights"
+		],
+		"MinimumLevel": {
+			"Default": "Information"
+		},
+		"WriteTo": [
+			{
+				"Name": "Console"
+			},
+			{
+				"Name": "ApplicationInsights",
+				"Args": {
+					"telemetryConverter": "Serilog.Sinks.ApplicationInsights.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
+				}
+			}
+		],
+		"Enrich": [
+			"FromLogContext",
+			"WithMachineName",
+			"WithThreadId"
+		],
+		"Destructure": []
+	}
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/host.json
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/host.json
@@ -1,0 +1,11 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            }
+        }
+    }
+}

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -4,15 +4,16 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
-    <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.8" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.1-preview-master" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.10" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -4,16 +4,16 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.1-preview-master" />
+    <PackageReference Include="Amido.Stacks.Messaging.Azure.EventHub" Version="0.2.2-preview-master" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.2.0" />
     <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.10" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.2.0" />
-    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1"/>
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0"/>
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1"/>
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">

--- a/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
+++ b/src/functions/func-aeh-listener/xxAMIDOxx.xxSTACKSxx.Listener/xxAMIDOxx.xxSTACKSxx.Listener.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
+    <PackageReference Include="Amido.Stacks.Application.CQRS.Events" Version="0.2.8" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.11" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="3.1.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
3387 - Add event hub publisher to API

#### 📲 What

Add the event hub package in the CQRS events API solution.
Configure the solution template, add "eventPublisher" parameter to set the type of event publishing to use.

#### 🤔 Why

This is needed to configure the cqrs events api solution to use either no event publishing, service bus or event hub depending on the users requirements.

#### 🛠 How

Usage of template:

dotnet new stacks-app-cqrs-events --name Foo.Bar --domain Car --eventPublisher "ServiceBus"
dotnet new stacks-app-cqrs-events --name Foo.Bar --domain Car --eventPublisher "EventHub"
dotnet new stacks-app-cqrs-events --name Foo.Bar --domain Car --eventPublisher "None"

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
