### PR TITLE
3617 - Wrap cosmos DB into .Net CLI argument

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -47,6 +47,29 @@
 			],
 			"description": "Adds event publishing."
 		},
+		"database": {
+			"type": "parameter",
+			"datatype": "choice",
+			"choices": [
+				{
+					"choice": "CosmosDb",
+					"description": "Targets Azure Cosmos database for storing data."
+				},
+				{
+					"choice": "DynamoDb",
+					"description": "Targets AWS Dynamo database for storing data."
+				}
+			],
+			"description": "Adds saving to database."
+		},
+		"CosmosDb": {
+			"type": "computed",
+			"value": "(database == \"CosmosDb\")"
+		},
+		"DynamoDb": {
+			"type": "computed",
+			"value": "(database == \"DynamoDb\")"
+		},
 		"EventPublisherServiceBus": {
 			"type": "computed",
 			"value": "(eventPublisher == \"ServiceBus\")"
@@ -97,6 +120,20 @@
 				"_gitattributes": ".gitattributes"
 			},
 			"modifiers": [
+				{
+					"condition": "(CosmosDb)",
+					"exclude": [
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs"
+					]
+				},
+				{
+					"condition": "(DynamoDb)",
+					"exclude": [
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs"
+					]
+				},
 				{
 					"condition": "(!enableFunctionWorker)",
 					"exclude": [

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
@@ -38,6 +38,9 @@
             "Source": "Environment"
         }
     },
+    "DynamoDb": {
+
+    },
     "JwtBearerAuthentication": {
         "Audience": "<TODO>",
         "Authority": "<TODO>",

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Amido.Stacks.Configuration;
@@ -16,7 +16,6 @@ using xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories;
 
 namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
 {
-
     /// <summary>
     /// The purpose of this integration test is to validate the implementation
     /// of MenuRepository againt the data store at development\integration
@@ -24,9 +23,9 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
     /// Configuration issues will be surfaced on e2e or acceptance tests
     /// </summary>
     [Trait("TestType", "IntegrationTests")]
-    public class MenuRepositoryTests
+    public class CosmosDbMenuRepositoryTests
     {
-        public MenuRepositoryTests()
+        public CosmosDbMenuRepositoryTests()
         {
             var settings = Configuration.For<CosmosDbConfiguration>("CosmosDB");
             //Notes:
@@ -53,7 +52,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
         /// the menu information and is retrieved properly
         /// </summary>
         [Theory, MenuRepositoryAutoData]
-        public async Task SaveAndGetTest(MenuRepository repository, Menu menu)
+        public async Task SaveAndGetTest(CosmosDbMenuRepository repository, Menu menu)
         {
             await repository.SaveAsync(menu);
             var dbItem = await repository.GetByIdAsync(menu.Id);
@@ -79,7 +78,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
         /// removes an existing menu and is not retrieved when requested
         /// </summary>
         [Theory, MenuRepositoryAutoData]
-        public async Task DeleteTest(MenuRepository repository, Menu menu)
+        public async Task DeleteTest(CosmosDbMenuRepository repository, Menu menu)
         {
             await repository.SaveAsync(menu);
             var dbItem = await repository.GetByIdAsync(menu.Id);

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
+{
+    /// <summary>
+    /// The purpose of this integration test is to validate the implementation
+    /// of MenuRepository againt the data store at development\integration
+    /// It is not intended to test if the configuration is valid for a release
+    /// Configuration issues will be surfaced on e2e or acceptance tests
+    /// </summary>
+    [Trait("TestType", "IntegrationTests")]
+    public class DynamoDbMenuRepositoryTests
+    {
+        public DynamoDbMenuRepositoryTests()
+        {
+
+        }
+    }
+}

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -66,8 +66,8 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
 #endif
 
             var healthChecks = services.AddHealthChecks();
-            healthChecks.AddCheck<CustomHealthCheck>("Sample"); //This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
 #if (CosmosDb)
+            healthChecks.AddCheck<CustomHealthCheck>("Sample"); //This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
             healthChecks.AddCheck<CosmosDbDocumentStorage<Menu>>("CosmosDB");
 #endif
         }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -39,10 +39,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
         /// <param name="services"></param>
         public static void ConfigureProductionDependencies(WebHostBuilderContext context, IServiceCollection services)
         {
-            services.Configure<CosmosDbConfiguration>(context.Configuration.GetSection("CosmosDb"));
-
             services.AddSecrets();
-            services.AddCosmosDB();
 
 #if (EventPublisherServiceBus)
             services.Configure<Amido.Stacks.Messaging.Azure.ServiceBus.Configuration.ServiceBusConfiguration>(context.Configuration.GetSection("ServiceBusConfiguration"));
@@ -56,14 +53,23 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
             services.AddTransient<IApplicationEventPublisher, DummyEventPublisher>();
 #endif
 
-            if (Environment.GetEnvironmentVariable("USE_MEMORY_STORAGE") == null)
-                services.AddTransient<IMenuRepository, MenuRepository>();
-            else
-                services.AddTransient<IMenuRepository, InMemoryMenuRepository>();
+#if (CosmosDb)
+            services.Configure<CosmosDbConfiguration>(context.Configuration.GetSection("CosmosDb"));
+            services.AddCosmosDB();
+            services.AddTransient<IMenuRepository, CosmosDbMenuRepository>();
+#elif (DynamoDb)
+            //services.Configure<DynamoDbConfiguration>(context.Configuration.GetSection("DynamoDb"));
+            //services.AddDynamoDB();
+            //services.AddTransient<IMenuRepository, DynamoDbMenuRepository>();
+#else
+            services.AddTransient<IMenuRepository, InMemoryMenuRepository>();
+#endif
 
             var healthChecks = services.AddHealthChecks();
+            healthChecks.AddCheck<CustomHealthCheck>("Sample"); //This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
+#if (DynamoDb)
             healthChecks.AddCheck<CosmosDbDocumentStorage<Menu>>("CosmosDB");
-            healthChecks.AddCheck<CustomHealthCheck>("Sample");//This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
+#endif
         }
 
         private static void AddCommandHandlers(IServiceCollection services)

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -67,7 +67,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
 
             var healthChecks = services.AddHealthChecks();
             healthChecks.AddCheck<CustomHealthCheck>("Sample"); //This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
-#if (DynamoDb)
+#if (CosmosDb)
             healthChecks.AddCheck<CosmosDbDocumentStorage<Menu>>("CosmosDB");
 #endif
         }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs
@@ -6,11 +6,11 @@ using xxAMIDOxx.xxSTACKSxx.Domain;
 
 namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories
 {
-    public class MenuRepository : IMenuRepository
+    public class CosmosDbMenuRepository : IMenuRepository
     {
         readonly IDocumentStorage<Menu> documentStorage;
 
-        public MenuRepository(IDocumentStorage<Menu> documentStorage)
+        public CosmosDbMenuRepository(IDocumentStorage<Menu> documentStorage)
         {
             this.documentStorage = documentStorage;
         }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using xxAMIDOxx.xxSTACKSxx.Application.Integration;
+using xxAMIDOxx.xxSTACKSxx.Domain;
+
+namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories
+{
+    public class DynamoDbMenuRepository : IMenuRepository
+    {
+        public DynamoDbMenuRepository()
+        {
+            
+        }
+
+        public async Task<Menu> GetByIdAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<bool> SaveAsync(Menu entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<bool> DeleteAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+


### PR DESCRIPTION
3617 - Wrap cosmos DB into .Net CLI argument

#### 📲 What

Adding --database arguments to the .net templating to configure the project solution to use either CosmosDb/DynamoDb or InMemory database via the CLI.

#### 🤔 Why

So that the user can set up cofniguration based on their selected database configuration. Not need to remove any unused and irrelevant code.

#### 🛠 How

Achieved by using template arguments on c# pre processor directives within code.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
