### PR TITLE
[3949] CLI framework version check

### DIFF
--- a/stackscli.yml
+++ b/stackscli.yml
@@ -1,0 +1,31 @@
+# Configuration file for setting up the project
+
+framework:
+  name: dotnet
+  commands:
+    - name: dotnet
+      version: ">= 3.1, > 3.2"
+
+# Pipeline files
+pipeline:
+  - type: azdo
+    files:
+      - name: build
+        path: build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+      - name: variable
+        path: build/azDevOps/azure/azuredevops-vars.yml
+    replacements:
+      - pattern: ^.*stacks-credentials-nonprod-kv$
+        value: ""
+
+# The init stage are things that are required to run before the template is run
+init:
+  operations:
+    - action: cmd
+      cmd: dotnet
+      args: new -i .
+      desc: Install "stacks-cqrs-events-app" template from the repo directory
+    - action: cmd
+      cmd: dotnet
+      args: new stacks-cqrs-events-app -n {{ .Input.Business.Company }}.{{ .Input.Business.Domain }} -o {{ .Project.Directory.WorkingDir }} -e {{ or .Project.Framework.Properties.Prop1 "servicebus"}}
+      desc: Create a project using the "stacks-cqrs-app" template


### PR DESCRIPTION
📲 What

Allow the CLI to check the version of a framework tool
Set a property, and default value, for specifying `servicebus` or `eventhub`

🤔 Why

Projects may require a specific version of framework tools
Need to be able to set the different variant that the template supports

🛠 How

The CLI has been updated so that the stackscli.yml file can now specify the constraints of a framework tool
This is based on semantic versioning and allows the CLI to check if the correct version of tools are available for each project

Updated the Go template for the project settings so that the properties can be accessed.

👀 Evidence

CLI Documentation has been updated with the new structure and an example of the user interaction

🕵️ How to test

Notes for QA
✅ Acceptance criteria Checklist

Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest changes from development and re-tested?
Meeting the Coding Standards?